### PR TITLE
Support multi-part issue

### DIFF
--- a/curlify.py
+++ b/curlify.py
@@ -41,8 +41,8 @@ def to_curl(request, compressed=False, verify=True):
     flat_parts = []
     for k, v in parts:
         if k:
-            flat_parts.append(quote(k))
+            flat_parts.append(quote(str(k)))
         if v:
-            flat_parts.append(quote(v))
+            flat_parts.append(quote(str(v)))
 
     return ' '.join(flat_parts)


### PR DESCRIPTION
I was getting this error on a file upload:
```TypeError: expected string or bytes-like object, got 'MultipartEncoderMonitor'```
this casts it to string before quote'ing it